### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/wiredthing/utils.png?label=ready&title=Ready)](https://waffle.io/wiredthing/utils)
 [![Build Status](https://travis-ci.org/WiredThing/utils.svg?branch=master)](https://travis-ci.org/WiredThing/utils)
 [![Codacy Badge](https://www.codacy.com/project/badge/95f3134af4dd406c901cf7f0895bff02)](https://www.codacy.com/public/doug/utils)
 [![Join the chat at https://gitter.im/WiredThing/utils](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/WiredThing/utils?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/wiredthing/utils

This was requested by a real person (user DougC) on waffle.io, we're not trying to spam you.